### PR TITLE
Add ping and help commands

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DISCORD_BOT_TOKEN=your-token-here

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-uv pip install -e .
+	uv pip install -e .
 
 run:
-python -m sfc_bot.bot
+	python -m sfc_bot.bot

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+install:
+uv pip install -e .
+
+run:
+python -m sfc_bot.bot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "sfc-discord-bot"
+version = "0.1.0"
+dependencies = [
+    "discord.py>=2.3",
+    "python-dotenv>=1.0",
+]
+
+[tool.uv]
+# uv will read dependencies from [project]

--- a/sfc_bot/__init__.py
+++ b/sfc_bot/__init__.py
@@ -1,0 +1,5 @@
+"""SFC Discord bot package."""
+
+from .bot import main
+
+__all__ = ["main"]

--- a/sfc_bot/bot.py
+++ b/sfc_bot/bot.py
@@ -9,14 +9,15 @@ TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 
 intents = discord.Intents.default()
 
-bot = commands.Bot(command_prefix="!", intents=intents, help_command=None)
-
+bot = commands.Bot(command_prefix=commands.when_mentioned_or("!"),
+    intents=intents,
+    help_command=None,
+    activity=discord.Game("<@mention> help"))
 
 @bot.command(name="ping")
 async def ping(ctx: commands.Context):
     """Respond with pong."""
     await ctx.send("Pong!")
-
 
 @bot.command(name="help")
 async def help_command(ctx: commands.Context):
@@ -24,10 +25,8 @@ async def help_command(ctx: commands.Context):
     help_text = "!ping: Respond with 'Pong!'\n!help: Show this help message."
     await ctx.send(help_text)
 
-
 def main() -> None:
     bot.run(TOKEN)
-
 
 if __name__ == "__main__":
     main()

--- a/sfc_bot/bot.py
+++ b/sfc_bot/bot.py
@@ -1,0 +1,33 @@
+import os
+from dotenv import load_dotenv
+import discord
+from discord.ext import commands
+
+load_dotenv()
+
+TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+
+intents = discord.Intents.default()
+
+bot = commands.Bot(command_prefix="!", intents=intents, help_command=None)
+
+
+@bot.command(name="ping")
+async def ping(ctx: commands.Context):
+    """Respond with pong."""
+    await ctx.send("Pong!")
+
+
+@bot.command(name="help")
+async def help_command(ctx: commands.Context):
+    """Display help information."""
+    help_text = "!ping: Respond with 'Pong!'\n!help: Show this help message."
+    await ctx.send(help_text)
+
+
+def main() -> None:
+    bot.run(TOKEN)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up a tiny `sfc_bot` package
- implement a Discord bot with `!ping` and `!help` commands
- configure dependencies in `pyproject.toml` for `uv`
- add Makefile targets to install deps and run the bot
- include `.env` with placeholder token

## Testing
- `python -m py_compile sfc_bot/bot.py`

------
https://chatgpt.com/codex/tasks/task_b_6846e87ce19c8325a898acfc306329da