### PR TITLE
Refactor bot with birthday reminder cog

### DIFF
--- a/sfc_bot/bot.py
+++ b/sfc_bot/bot.py
@@ -46,5 +46,4 @@ async def main() -> None:
 
 if __name__ == "__main__":
     import asyncio
-
     asyncio.run(main())

--- a/sfc_bot/bot.py
+++ b/sfc_bot/bot.py
@@ -1,7 +1,6 @@
+from __future__ import annotations
+
 import os
-import json
-from datetime import datetime
-from pathlib import Path
 
 from dotenv import load_dotenv
 import discord
@@ -13,32 +12,22 @@ TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 
 intents = discord.Intents.default()
 
-BIRTHDAY_FILE = Path("birthdays.json")
-
-def load_birthdays() -> dict:
-    if BIRTHDAY_FILE.exists():
-        with BIRTHDAY_FILE.open() as f:
-            return json.load(f)
-    return {}
-
-birthdays = load_birthdays()
-
-def save_birthdays() -> None:
-    with BIRTHDAY_FILE.open("w") as f:
-        json.dump(birthdays, f)
-
-bot = commands.Bot(command_prefix=commands.when_mentioned_or("!"),
+bot = commands.Bot(
+    command_prefix=commands.when_mentioned_or("!"),
     intents=intents,
     help_command=None,
-    activity=discord.Game("<@mention> help"))
+    activity=discord.Game("<@mention> help"),
+)
+
 
 @bot.command(name="ping")
-async def ping(ctx: commands.Context):
+async def ping(ctx: commands.Context) -> None:
     """Respond with pong."""
     await ctx.send("Pong!")
 
+
 @bot.command(name="help")
-async def help_command(ctx: commands.Context):
+async def help_command(ctx: commands.Context) -> None:
     """Display help information."""
     help_text = (
         "!ping: Respond with 'Pong!'\n"
@@ -50,58 +39,12 @@ async def help_command(ctx: commands.Context):
     await ctx.send(help_text)
 
 
-@bot.group(name="birthday", invoke_without_command=True)
-async def birthday_group(ctx: commands.Context):
-    """Manage birthday reminders."""
-    await ctx.send(
-        "Use '!birthday set MM-DD' to register your birthday, "
-        "'!birthday today' to see today's birthdays, or "
-        "'!birthday list' to list birthdays."
-    )
+async def main() -> None:
+    await bot.load_extension("sfc_bot.reminders.birthday")
+    await bot.start(TOKEN)
 
-
-@birthday_group.command(name="set")
-async def birthday_set(ctx: commands.Context, date: str):
-    """Register your birthday in MM-DD format."""
-    try:
-        datetime.strptime(date, "%m-%d")
-    except ValueError:
-        await ctx.send("Date must be in MM-DD format.")
-        return
-    birthdays[str(ctx.author.id)] = date
-    save_birthdays()
-    await ctx.send(f"Birthday for {ctx.author.display_name} set to {date}.")
-
-
-@birthday_group.command(name="today")
-async def birthday_today(ctx: commands.Context):
-    """Show birthdays happening today."""
-    today = datetime.now().strftime("%m-%d")
-    mentions = [
-        (await bot.fetch_user(int(uid))).mention
-        for uid, date in birthdays.items()
-        if date == today
-    ]
-    if mentions:
-        await ctx.send("Today's birthdays: " + ", ".join(mentions))
-    else:
-        await ctx.send("No birthdays today.")
-
-
-@birthday_group.command(name="list")
-async def birthday_list(ctx: commands.Context):
-    """List all registered birthdays."""
-    if not birthdays:
-        await ctx.send("No birthdays registered.")
-        return
-    entries = []
-    for uid, date in sorted(birthdays.items(), key=lambda x: x[1]):
-        user = await bot.fetch_user(int(uid))
-        entries.append(f"{date}: {user.display_name}")
-    await ctx.send("\n".join(entries))
-
-def main() -> None:
-    bot.run(TOKEN)
 
 if __name__ == "__main__":
-    main()
+    import asyncio
+
+    asyncio.run(main())

--- a/sfc_bot/reminders/base.py
+++ b/sfc_bot/reminders/base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, time
+from typing import Tuple
+
+from discord.ext import commands
+
+class ScheduledReminderCog(commands.Cog, ABC):
+    """Base class for reminders that run at a scheduled time each day."""
+
+    #: Time to trigger the reminder each day as (hour, minute).
+    SCHEDULE_TIME: Tuple[int, int] = (0, 1)
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._task = self.bot.loop.create_task(self._schedule_loop())
+
+    async def cog_unload(self) -> None:
+        self._task.cancel()
+
+    async def _schedule_loop(self) -> None:
+        await self.bot.wait_until_ready()
+        while not self.bot.is_closed():
+            now = datetime.now()
+            target = datetime.combine(now.date(), time(*self.SCHEDULE_TIME))
+            if target <= now:
+                target += timedelta(days=1)
+            await asyncio.sleep((target - now).total_seconds())
+            await self.send_due_reminders()
+
+    @abstractmethod
+    async def send_due_reminders(self) -> None:
+        """Send reminders that are due."""
+        raise NotImplementedError

--- a/sfc_bot/reminders/base.py
+++ b/sfc_bot/reminders/base.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from datetime import datetime, timedelta, time
 from typing import Tuple
 
 from discord.ext import commands
 
-class ScheduledReminderCog(commands.Cog, ABC):
+class ScheduledReminderCog(commands.Cog):
     """Base class for reminders that run at a scheduled time each day."""
 
     #: Time to trigger the reminder each day as (hour, minute).

--- a/sfc_bot/reminders/base.py
+++ b/sfc_bot/reminders/base.py
@@ -2,33 +2,25 @@ from __future__ import annotations
 
 import asyncio
 from abc import abstractmethod
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta, timezone, time
 from typing import Tuple
 
-from discord.ext import commands
+from discord.ext import tasks, commands
+
+SCHEDULE_TIME = [time(hour=0, minute=1, tzinfo=timezone(timedelta(hours=+9), 'JST'))]
 
 class ScheduledReminderCog(commands.Cog):
     """Base class for reminders that run at a scheduled time each day."""
 
-    #: Time to trigger the reminder each day as (hour, minute).
-    SCHEDULE_TIME: Tuple[int, int] = (0, 1)
-
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self._task = self.bot.loop.create_task(self._schedule_loop())
 
-    async def cog_unload(self) -> None:
-        self._task.cancel()
+    async def cog_unload(self) -> None: pass
 
-    async def _schedule_loop(self) -> None:
+    @tasks.loop(time=SCHEDULE_TIME)
+    async def _on_ready(self) -> None:
         await self.bot.wait_until_ready()
-        while not self.bot.is_closed():
-            now = datetime.now()
-            target = datetime.combine(now.date(), time(*self.SCHEDULE_TIME))
-            if target <= now:
-                target += timedelta(days=1)
-            await asyncio.sleep((target - now).total_seconds())
-            await self.send_due_reminders()
+        await self.send_due_reminders()
 
     @abstractmethod
     async def send_due_reminders(self) -> None:

--- a/sfc_bot/reminders/birthday.py
+++ b/sfc_bot/reminders/birthday.py
@@ -11,14 +11,9 @@ from discord.ext import commands
 from .base import ScheduledReminderCog
 
 BIRTHDAY_FILE = Path("birthdays.csv")
-# Time of day when birthday checks run (hour, minute). Useful for tests.
-CHECK_TIME = (0, 1)
 
 class BirthdayReminder(ScheduledReminderCog):
     """Cog handling birthday reminders."""
-
-    SCHEDULE_TIME = CHECK_TIME
-
     def __init__(self, bot: commands.Bot) -> None:
         self.birthdays: Dict[str, str] = {}
         super().__init__(bot)

--- a/sfc_bot/reminders/birthday.py
+++ b/sfc_bot/reminders/birthday.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+import discord
+from discord.ext import commands
+
+from .base import ScheduledReminderCog
+
+BIRTHDAY_FILE = Path("birthdays.csv")
+# Time of day when birthday checks run (hour, minute). Useful for tests.
+CHECK_TIME = (0, 1)
+
+class BirthdayReminder(ScheduledReminderCog):
+    """Cog handling birthday reminders."""
+
+    SCHEDULE_TIME = CHECK_TIME
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.birthdays: Dict[str, str] = {}
+        super().__init__(bot)
+        self._load_birthdays()
+
+    def _load_birthdays(self) -> None:
+        if BIRTHDAY_FILE.exists():
+            with BIRTHDAY_FILE.open(newline="") as f:
+                reader = csv.reader(f)
+                self.birthdays = {uid: date for uid, date in reader}
+
+    def _save_birthdays(self) -> None:
+        with BIRTHDAY_FILE.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerows(self.birthdays.items())
+
+    @commands.group(name="birthday", invoke_without_command=True)
+    async def birthday_group(self, ctx: commands.Context) -> None:
+        """Manage birthday reminders."""
+        await ctx.send(
+            "Use '!birthday set MM-DD' to register your birthday, "
+            "'!birthday today' to see today's birthdays, or "
+            "'!birthday list' to list birthdays."
+        )
+
+    @birthday_group.command(name="set")
+    async def birthday_set(self, ctx: commands.Context, date: str) -> None:
+        """Register your birthday in MM-DD format."""
+        try:
+            datetime.strptime(date, "%m-%d")
+        except ValueError:
+            await ctx.send("Date must be in MM-DD format.")
+            return
+        self.birthdays[str(ctx.author.id)] = date
+        self._save_birthdays()
+        await ctx.send(f"Birthday for {ctx.author.display_name} set to {date}.")
+
+    @birthday_group.command(name="today")
+    async def birthday_today(self, ctx: commands.Context) -> None:
+        """Show birthdays happening today."""
+        await self._announce_birthdays(ctx.channel)
+
+    @birthday_group.command(name="list")
+    async def birthday_list(self, ctx: commands.Context) -> None:
+        """List all registered birthdays."""
+        if not self.birthdays:
+            await ctx.send("No birthdays registered.")
+            return
+        entries = []
+        for uid, date in sorted(self.birthdays.items(), key=lambda x: x[1]):
+            user = await self.bot.fetch_user(int(uid))
+            entries.append(f"{date}: {user.display_name}")
+        await ctx.send("\n".join(entries))
+
+    async def send_due_reminders(self) -> None:
+        today = datetime.now().strftime("%m-%d")
+        if not self.birthdays:
+            return
+        mentions = [
+            (await self.bot.fetch_user(int(uid))).mention
+            for uid, date in self.birthdays.items()
+            if date == today
+        ]
+        if not mentions:
+            return
+        message = "Today's birthdays: " + ", ".join(mentions)
+        for guild in self.bot.guilds:
+            channel = guild.system_channel or next(
+                (c for c in guild.text_channels if c.permissions_for(guild.me).send_messages),
+                None,
+            )
+            if channel:
+                await channel.send(message)
+
+    async def _announce_birthdays(self, channel: discord.abc.Messageable) -> None:
+        today = datetime.now().strftime("%m-%d")
+        mentions = [
+            (await self.bot.fetch_user(int(uid))).mention
+            for uid, date in self.birthdays.items()
+            if date == today
+        ]
+        if mentions:
+            await channel.send("Today's birthdays: " + ", ".join(mentions))
+        else:
+            await channel.send("No birthdays today.")
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BirthdayReminder(bot))


### PR DESCRIPTION
## Summary
- refactor bot to use cogs
- implement `ScheduledReminderCog` for daily scheduled reminders
- move birthday logic into `BirthdayReminder` using CSV storage
- load birthday cog from the main bot module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6846eca7b7cc832582b0d0320eebb856