### PR TITLE
Add advanced birthday features

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,3 +9,7 @@ A simple Discord bot with ping and birthday reminder commands.
 - `!birthday set MM-DD` - Register your birthday.
 - `!birthday today` - Show birthdays happening today.
 - `!birthday list` - List all registered birthdays.
+- `!notification <channel_id>` - Set the channel where birthday reminders are sent.
+
+The birthday list command now replies with a calendar image showing each
+member's avatar on their birthday.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 dependencies = [
     "discord.py>=2.3",
     "python-dotenv>=1.0",
+    "opencv-python-headless>=4.8",
+    "Pillow>=9.5",
 ]
 
 [tool.uv]

--- a/sfc_bot/bot.py
+++ b/sfc_bot/bot.py
@@ -34,7 +34,8 @@ async def help_command(ctx: commands.Context) -> None:
         "!help: Show this help message.\n"
         "!birthday set MM-DD: Set your birthday.\n"
         "!birthday today: Show birthdays today.\n"
-        "!birthday list: List all registered birthdays."
+        "!birthday list: Show birthday calendar.\n"
+        "!notification <channel_id>: Set reminder channel."
     )
     await ctx.send(help_text)
 

--- a/sfc_bot/reminders/birthday.py
+++ b/sfc_bot/reminders/birthday.py
@@ -3,21 +3,30 @@ from __future__ import annotations
 import csv
 from datetime import datetime
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
+import io
+import random
+import calendar
 
 import discord
 from discord.ext import commands
+import cv2
+import numpy as np
+from PIL import Image, ImageDraw
 
 from .base import ScheduledReminderCog
 
 BIRTHDAY_FILE = Path("birthdays.csv")
+NOTIFICATION_FILE = Path("notification_channels.csv")
 
 class BirthdayReminder(ScheduledReminderCog):
     """Cog handling birthday reminders."""
     def __init__(self, bot: commands.Bot) -> None:
         self.birthdays: Dict[str, str] = {}
+        self.notification_channels: Dict[str, str] = {}
         super().__init__(bot)
         self._load_birthdays()
+        self._load_notifications()
 
     def _load_birthdays(self) -> None:
         if BIRTHDAY_FILE.exists():
@@ -29,6 +38,33 @@ class BirthdayReminder(ScheduledReminderCog):
         with BIRTHDAY_FILE.open("w", newline="") as f:
             writer = csv.writer(f)
             writer.writerows(self.birthdays.items())
+
+    def _load_notifications(self) -> None:
+        if NOTIFICATION_FILE.exists():
+            with NOTIFICATION_FILE.open(newline="") as f:
+                reader = csv.reader(f)
+                self.notification_channels = {gid: cid for gid, cid in reader}
+
+    def _save_notifications(self) -> None:
+        with NOTIFICATION_FILE.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerows(self.notification_channels.items())
+
+    @commands.command(name="notification")
+    @commands.has_guild_permissions(administrator=True)
+    async def set_notification(self, ctx: commands.Context, channel_id: str) -> None:
+        """Set the channel to use for reminders."""
+        if not ctx.guild:
+            await ctx.send("This command can only be used in a server.")
+            return
+        try:
+            int(channel_id)
+        except ValueError:
+            await ctx.send("Invalid channel ID.")
+            return
+        self.notification_channels[str(ctx.guild.id)] = channel_id
+        self._save_notifications()
+        await ctx.send(f"Notification channel set to <#{channel_id}>.")
 
     @commands.group(name="birthday", invoke_without_command=True)
     async def birthday_group(self, ctx: commands.Context) -> None:
@@ -58,45 +94,115 @@ class BirthdayReminder(ScheduledReminderCog):
 
     @birthday_group.command(name="list")
     async def birthday_list(self, ctx: commands.Context) -> None:
-        """List all registered birthdays."""
+        """Reply with a calendar image of all birthdays."""
         if not self.birthdays:
             await ctx.send("No birthdays registered.")
             return
-        entries = []
-        for uid, date in sorted(self.birthdays.items(), key=lambda x: x[1]):
-            user = await self.bot.fetch_user(int(uid))
-            entries.append(f"{date}: {user.display_name}")
-        await ctx.send("\n".join(entries))
+        file = await self._create_calendar_image()
+        await ctx.send(file=file)
+
+    async def _create_calendar_image(self) -> discord.File:
+        """Create a calendar image with avatars on birthdays."""
+        year = datetime.now().year
+        month = datetime.now().month
+        cal = calendar.monthcalendar(year, month)
+        cell_w, cell_h = 100, 80
+        img_h = cell_h * (len(cal) + 1)
+        img_w = cell_w * 7
+        img = np.ones((img_h, img_w, 3), dtype=np.uint8) * 255
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        cv2.putText(img, f"{year}-{month:02d}", (5, 20), font, 0.6, (0, 0, 0), 2)
+        for r, week in enumerate(cal):
+            for c, day in enumerate(week):
+                x, y = c * cell_w, (r + 1) * cell_h
+                cv2.rectangle(img, (x, y), (x + cell_w, y + cell_h), (0, 0, 0), 1)
+                if day:
+                    cv2.putText(img, str(day), (x + 2, y + 15), font, 0.5, (0, 0, 0), 1)
+                    key = f"{month:02d}-{day:02d}"
+                    uids = [uid for uid, d in self.birthdays.items() if d == key]
+                    offset = 0
+                    for uid in uids:
+                        user = await self.bot.fetch_user(int(uid))
+                        data = await user.display_avatar.read()
+                        avatar = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_UNCHANGED)
+                        if avatar is None:
+                            continue
+                        avatar = cv2.resize(avatar, (32, 32))
+                        if avatar.shape[2] == 4:
+                            alpha = avatar[:, :, 3] / 255.0
+                            for cidx in range(3):
+                                img[y + 20 + offset : y + 52 + offset, x + 2 : x + 34, cidx] = (
+                                    alpha * avatar[:, :, cidx]
+                                    + (1 - alpha)
+                                    * img[y + 20 + offset : y + 52 + offset, x + 2 : x + 34, cidx]
+                                )
+                        else:
+                            img[y + 20 + offset : y + 52 + offset, x + 2 : x + 34] = avatar
+                        offset += 34
+        buf = io.BytesIO()
+        _, arr = cv2.imencode(".png", img)
+        buf.write(arr.tobytes())
+        buf.seek(0)
+        return discord.File(fp=buf, filename="birthdays.png")
 
     async def send_due_reminders(self) -> None:
         today = datetime.now().strftime("%m-%d")
         if not self.birthdays:
             return
-        mentions = [
-            (await self.bot.fetch_user(int(uid))).mention
-            for uid, date in self.birthdays.items()
-            if date == today
-        ]
-        if not mentions:
-            return
-        message = "Today's birthdays: " + ", ".join(mentions)
         for guild in self.bot.guilds:
+            members = [m for m in guild.members if self.birthdays.get(str(m.id)) == today]
+            if not members:
+                continue
+            channel = self._get_notification_channel(guild)
+            if not channel:
+                continue
+            mentions = [m.mention for m in members]
+            message = random.choice(["🎂", "🍰", "🥳", "🎉"]) + " " + ", ".join(mentions)
+            card = await self._create_birthday_card(members)
+            await channel.send(message, file=card)
+
+    def _get_notification_channel(self, guild: discord.Guild) -> discord.abc.Messageable | None:
+        channel_id = self.notification_channels.get(str(guild.id))
+        channel = None
+        if channel_id:
+            channel = guild.get_channel(int(channel_id))
+        if channel is None:
             channel = guild.system_channel or next(
                 (c for c in guild.text_channels if c.permissions_for(guild.me).send_messages),
                 None,
             )
-            if channel:
-                await channel.send(message)
+        return channel
+
+    async def _create_birthday_card(self, members: List[discord.Member]) -> discord.File:
+        width = 200 + 80 * len(members)
+        height = 180
+        img = Image.new("RGB", (width, height), "white")
+        draw = ImageDraw.Draw(img)
+        emoji = random.choice(["🎂", "🍰", "🥳", "🎉"])
+        draw.text((10, 10), f"Happy Birthday {emoji}", fill="black")
+        x = 10
+        for m in members:
+            data = await m.display_avatar.read()
+            avatar = Image.open(io.BytesIO(data)).convert("RGBA").resize((64, 64))
+            img.paste(avatar, (x, 40), avatar)
+            draw.text((x, 110), m.display_name, fill="black")
+            x += 80
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        return discord.File(fp=buf, filename="card.png")
 
     async def _announce_birthdays(self, channel: discord.abc.Messageable) -> None:
         today = datetime.now().strftime("%m-%d")
-        mentions = [
-            (await self.bot.fetch_user(int(uid))).mention
-            for uid, date in self.birthdays.items()
-            if date == today
-        ]
-        if mentions:
-            await channel.send("Today's birthdays: " + ", ".join(mentions))
+        guild = getattr(channel, "guild", None)
+        if guild:
+            members = [m for m in guild.members if self.birthdays.get(str(m.id)) == today]
+        else:
+            members = [await self.bot.fetch_user(int(uid)) for uid, d in self.birthdays.items() if d == today]
+        if members:
+            mentions = [m.mention for m in members]
+            card = await self._create_birthday_card(members)
+            await channel.send("Today's birthdays: " + ", ".join(mentions), file=card)
         else:
             await channel.send("No birthdays today.")
 


### PR DESCRIPTION
## Summary
- allow configuring a notification channel via `!notification`
- send birthday reminders to the configured channel with a simple card
- show birthday lists as a calendar image
- update help text and documentation
- include pillow and opencv in dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6846f47b6dbc8325891e54b244b1a454